### PR TITLE
Switch from curl to reqwest for HTTP requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.2", features = ["derive"]}
 serde_json = "1.0.2"
 serde_derive = "1.0.2"
 md5 = "0.7.0"
-curl = "0.4.6"
+reqwest = { version = "0.11.22", features = ["blocking", "multipart"] }
 
 [dependencies.deflate]
 version = "1.0.0"


### PR DESCRIPTION
Closes #9

Instead of using the [curl](https://crates.io/crates/curl) crate that requires compiled-in curl libraries, this PR switches the used HTTP client to the [reqwest](https://crates.io/crates/reqwest) crate.

I was able to successfully pass all tests on my fork after setting up a coveralls token.

Note: It might make sense to refactor the crate API in a follow-up PR - having a separate `upload_status` function to check whether the upload was successful instead of returning the status of the HTTP request from the `send_to_*` methods seems more cumbersome than needed.

BREAKING CHANGES: 

1. the error type returned by the `send_to_coveralls` and `send_to_endpoint` functions has changed from `curl::Error` to `reqwest::Error`.
2. (`CoverallsReport` private fields have changed)